### PR TITLE
Configuration for WPA2 AES encryption

### DIFF
--- a/bash_script/wifi_extender.bash
+++ b/bash_script/wifi_extender.bash
@@ -98,6 +98,9 @@ config_wpsup() {
         echo '  ssid="'${NEW_SSID}'"'
         echo "  mode=2"
         echo "  key_mgmt=WPA-PSK"
+        echo "  proto=RSN"
+        echo "  pairwise=CCMP"
+        echo "  group=CCMP"
         echo '  psk='`generate_wpa2_psk $NEW_SSID $NEW_PASS`
         echo "  frequency=2412"
         echo "}"

--- a/bash_script/wifi_extender.bash
+++ b/bash_script/wifi_extender.bash
@@ -91,7 +91,7 @@ setup_systemd_networkd() {
 
 config_wpsup() {
     {
-        echo "country=IN"
+        echo "country=US"
         echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev"
         echo "update_config=1"
         echo "network={"
@@ -115,7 +115,7 @@ config_wpsup() {
 
 setup_wlan1_client() {
     {
-        echo "country=IN"
+        echo "country=US"
         echo "ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev"
         echo "update_config=1"
         echo "network={"
@@ -136,7 +136,7 @@ configure_interfaces() {
         echo "[Match]"
         echo "Name=$WLAN0"
         echo "[Network]"
-        echo "Address=192.168.7.1/24"
+        echo "Address=10.0.0.1/24"
         echo "IPMasquerade=yes"
         echo "IPForward=yes"
         echo "DHCPServer=yes"


### PR DESCRIPTION
Current AP code uses a lower security encryption than the standard WIFI encryption standard of WPA2 (AES).  This change will configure the AP to WPA2 (AES).